### PR TITLE
Embed static files

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"embed"
 	"errors"
 	"path/filepath"
 	"strconv"
@@ -21,6 +22,7 @@ const (
 
 var (
 	config ProjectConfig
+	TmplFS embed.FS
 )
 
 func GenerateServer(conf GeneratorConfig) {

--- a/generator/generatorUtils.go
+++ b/generator/generatorUtils.go
@@ -25,7 +25,7 @@ func createFileFromTemplate(filePath string, tmplPath string, config interface{}
 	defer file.Close()
 
 	// Parse the template and write into file
-	tmpl := template.Must(template.New(templateName).ParseFiles(tmplPath))
+	tmpl := template.Must(template.New(templateName).ParseFS(TmplFS, tmplPath))
 	tmplErr := tmpl.Execute(file, config)
 	if tmplErr != nil {
 		log.Fatal().Err(tmplErr).Msg("Failed executing template.")

--- a/generator/structsGenerator.go
+++ b/generator/structsGenerator.go
@@ -130,7 +130,7 @@ func generateImports() string {
 	templateFile := "templates/imports.go.tmpl"
 	buf := &bytes.Buffer{}
 
-	tmpl := template.Must(template.ParseFiles(templateFile))
+	tmpl := template.Must(template.ParseFS(TmplFS, templateFile))
 	if tmplErr := tmpl.Execute(buf, conf); tmplErr != nil {
 		log.Fatal().Err(tmplErr).Msg("Failed executing imports template.")
 	}

--- a/main.go
+++ b/main.go
@@ -1,18 +1,26 @@
 package main
 
 import (
+	"embed"
 	cli "go-open-api-generator/cli"
+	generator "go-open-api-generator/generator"
+
 	"os"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
+//go:embed templates
+var tmplFS embed.FS
+
 func main() {
 	// Set up zerolog time format
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	// Set pretty logging on
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	// Export embed FS to generator package
+	generator.TmplFS = tmplFS
 
 	cli.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"embed"
 	cli "go-open-api-generator/cli"
 	generator "go-open-api-generator/generator"
 
+	"embed"
 	"os"
 
 	"github.com/rs/zerolog"
@@ -19,7 +19,7 @@ func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	// Set pretty logging on
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	// Export embed FS to generator package
+	// Export embed template filesystem to generator package
 	generator.TmplFS = tmplFS
 
 	cli.Execute()


### PR DESCRIPTION
Compile each template in the `templates` directory into the `go build` binary so that it is portable and independent of the template directory at run time.

To access a template, use the `FS` [alternative](https://pkg.go.dev/io/fs#ReadFile) with the newly embedded `TmplFS` filesystem for every corresponding `ReadFile` command.