### PR TITLE
feat: added HTTP/2 support

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -16,6 +16,7 @@ var (
 	projectName  string
 	loggerFlag   bool
 	databaseFlag bool
+	http2Flag    bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -53,6 +54,7 @@ var generateCmd = &cobra.Command{
 			Flags: gen.Flags{
 				UseDatabase: databaseFlag,
 				UseLogger:   loggerFlag,
+				UseHTTP2:    http2Flag,
 			},
 		}
 
@@ -90,6 +92,7 @@ func init() {
 	generateCmd.Flags().StringVarP(&projectName, "name", "n", "", "module name of generated code (default is 'build')")
 	generateCmd.Flags().BoolVarP(&loggerFlag, "logger", "l", false, "use logging middleware in generated code (default is 'false')")
 	generateCmd.Flags().BoolVarP(&databaseFlag, "database", "d", false, "add sqlite3 database in generated code (default is 'false')")
+	generateCmd.Flags().BoolVarP(&http2Flag, "http2", "H", false, "use HTTP/2 in generated code (default is 'false')")
 
 	// add generate command
 	rootCmd.AddCommand(generateCmd)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -102,6 +102,10 @@ func generateServerTemplate(portSpec *openapi3.ServerVariable, generatorConf Gen
 		log.Info().Msg("Adding logging middleware.")
 	}
 
+	if generatorConf.UseHTTP2 {
+		log.Info().Msg("Using HTTP/2 as default protocol")
+	}
+
 	fileName := "main.go"
 	filePath := filepath.Join(config.Path, fileName)
 	templateFile := "templates/server.go.tmpl"

--- a/generator/types.go
+++ b/generator/types.go
@@ -3,6 +3,7 @@ package generator
 type Flags struct {
 	UseDatabase bool
 	UseLogger   bool
+	UseHTTP2    bool
 }
 
 type GeneratorConfig struct {

--- a/templates/server.go.tmpl
+++ b/templates/server.go.tmpl
@@ -53,5 +53,9 @@ func main() {
 	e.File("/doc", "public/index.html")
 	e.File("/{{.OpenAPIName}}.yaml", "public/{{.OpenAPIName}}.yaml")
 
+	{{- if .UseHTTP2}}
+	e.Logger.Fatal(e.StartTLS(":" + config.ServerPort, "cert.pem", "key.pem"))
+	{{else}}
 	e.Logger.Fatal(e.Start(":" + config.ServerPort))
+	{{end}}
 }


### PR DESCRIPTION
Added HTTP/2 Support for the generated server, via `-H` cli flag.

Prerequisite for HTTP/2 is a TLS connection, to generate a quick localhost certificate use either openssl or
`go run $GOROOT/src/crypto/tls/generate_cert.go --host localhost`
