### PR TITLE
Added lifecycle endpoints for generated code

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -12,11 +12,12 @@ import (
 
 // variables for the flags
 var (
-	projectPath  string
-	projectName  string
-	loggerFlag   bool
-	databaseFlag bool
-	http2Flag    bool
+	projectPath   string
+	projectName   string
+	loggerFlag    bool
+	databaseFlag  bool
+	http2Flag     bool
+	lifecycleFlag bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -52,9 +53,10 @@ var generateCmd = &cobra.Command{
 			ModuleName:   projectName,
 			DatabaseName: "database",
 			Flags: gen.Flags{
-				UseDatabase: databaseFlag,
-				UseLogger:   loggerFlag,
-				UseHTTP2:    http2Flag,
+				UseDatabase:  databaseFlag,
+				UseLogger:    loggerFlag,
+				UseHTTP2:     http2Flag,
+				UseLifecycle: lifecycleFlag,
 			},
 		}
 
@@ -93,6 +95,7 @@ func init() {
 	generateCmd.Flags().BoolVarP(&loggerFlag, "logger", "l", false, "use logging middleware in generated code (default is 'false')")
 	generateCmd.Flags().BoolVarP(&databaseFlag, "database", "d", false, "add sqlite3 database in generated code (default is 'false')")
 	generateCmd.Flags().BoolVarP(&http2Flag, "http2", "H", false, "use HTTP/2 in generated code (default is 'false')")
+	generateCmd.Flags().BoolVarP(&lifecycleFlag, "lifecycle", "L", false, "generate default livez and readyz endpoints (default is 'false')")
 
 	// add generate command
 	rootCmd.AddCommand(generateCmd)

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -163,7 +163,7 @@ func generateHandlerFuncStub(op *openapi3.Operation, method string, path string,
 	}
 
 	for resKey, resRef := range op.Responses {
-		if !validateStatusCode(resKey) {
+		if !validateStatusCode(resKey) && resKey != "default" {
 			log.Warn().Msg("Status code " + resKey + " for endpoint " + methodPath + " is not a valid status code.")
 		}
 

--- a/generator/generatorUtils.go
+++ b/generator/generatorUtils.go
@@ -77,3 +77,15 @@ func updateAuthConfig(spec *openapi3.T, conf *GeneratorConfig) {
 		}
 	}
 }
+
+func updateOAPIOperation(op *openapi3.Operation, opID string, opSummary string, opDefault int) {
+	op.OperationID = opID
+	op.Summary = opSummary
+	op.Responses.Default().Value = op.Responses.Get(opDefault).Value
+}
+
+func createOAPIResponse(rDesc string) *openapi3.Response {
+	r := openapi3.NewResponse()
+	r.Description = &rDesc
+	return r
+}

--- a/generator/types.go
+++ b/generator/types.go
@@ -1,9 +1,10 @@
 package generator
 
 type Flags struct {
-	UseDatabase bool
-	UseLogger   bool
-	UseHTTP2    bool
+	UseDatabase  bool
+	UseLogger    bool
+	UseHTTP2     bool
+	UseLifecycle bool
 }
 
 type AuthConfig struct {


### PR DESCRIPTION
Use the `-L` Flag to generate default `/lifez` and `/readyz` endpoints for container [usage and monitoring](https://kubernetes.io/docs/reference/using-api/health-checks/).

If one of the two endpoints is already defined in the input openapi specification, the specified endpoint is used.

Since adding a new path via the golang openapi3 package also adds the `default` [statuscode](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responsesObject), the statuscode check had to be modified in  52527acc377c903e27000061324dd7d61c6b7345.